### PR TITLE
Pages and Posts: featured_image is now featured_media

### DIFF
--- a/pages.go
+++ b/pages.go
@@ -25,6 +25,7 @@ type Page struct {
 	Author        int     `json:"author,omitempty"`
 	Excerpt       Excerpt `json:"excerpt,omitempty"`
 	FeaturedImage int     `json:"featured_image,omitempty"`
+	FeaturedMedia int     `json:"featured_media,omitempty"`
 	CommentStatus string  `json:"comment_status,omitempty"`
 	PingStatus    string  `json:"ping_status,omitempty"`
 	MenuOrder     int     `json:"menu_order,omitempty"`

--- a/posts.go
+++ b/posts.go
@@ -71,6 +71,7 @@ type Post struct {
 	Author        int     `json:"author,omitempty"`
 	Excerpt       Excerpt `json:"excerpt,omitempty"`
 	FeaturedImage int     `json:"featured_image,omitempty"`
+	FeaturedMedia int     `json:"featured_media,omitempty"`
 	CommentStatus string  `json:"comment_status,omitempty"`
 	PingStatus    string  `json:"ping_status,omitempty"`
 	Format        string  `json:"format,omitempty"`


### PR DESCRIPTION
I've been trying to use this lib with a headless WordPress, but I cannot fetch the featured image on pages and posts.
It seems the WordPress API now returns `featured_media` instead of `featured_image`.
This commit adds it as a new field in both structs. I did not remove the old field in order to keep backwards compatibility.